### PR TITLE
add a build version fro the console's release candidate 1.13.0-rc.1

### DIFF
--- a/1.13.0-rc.1/Dockerfile
+++ b/1.13.0-rc.1/Dockerfile
@@ -1,0 +1,7 @@
+FROM nginx:alpine
+
+WORKDIR /usr/share/nginx/html
+
+ENV OPENHIM_CONSOLE_VERSION 1.13.0-rc.1
+
+RUN wget -qO- "https://github.com/jembi/openhim-console/releases/download/v$OPENHIM_CONSOLE_VERSION/openhim-console-v$OPENHIM_CONSOLE_VERSION.tar.gz" | tar xvz


### PR DESCRIPTION
This is so that the console release candidate can be built seperate from the proper releases

OHM-738 OHM-736