### PR TITLE
Bump the release candidate version in the Dockerfile to match the version in the core repository

### DIFF
--- a/5.rc/Dockerfile
+++ b/5.rc/Dockerfile
@@ -3,7 +3,7 @@ FROM node:10
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
-ENV OPENHIM_CORE_VERSION 5.0.0-rc.1
+ENV OPENHIM_CORE_VERSION 5.0.0-rc.2
 
 RUN curl -sL "https://github.com/jembi/openhim-core-js/archive/v$OPENHIM_CORE_VERSION.tar.gz" | \
     tar --strip-components=1 -zxvf - && \


### PR DESCRIPTION
OHM-373