### PR TITLE
OHM-837 console release 1.13.2

### DIFF
--- a/1.13/Dockerfile
+++ b/1.13/Dockerfile
@@ -1,7 +1,10 @@
 FROM nginx:alpine
 
-WORKDIR /usr/share/nginx/html
-
 ENV OPENHIM_CONSOLE_VERSION 1.13.2
 
+WORKDIR /etc
 RUN wget -qO- "https://github.com/jembi/openhim-console/releases/download/v$OPENHIM_CONSOLE_VERSION/openhim-console-v$OPENHIM_CONSOLE_VERSION.tar.gz" | tar xvz
+
+WORKDIR /usr/share/nginx
+RUN rm -rf html
+RUN ln -s /etc/openhim-console/dist html


### PR DESCRIPTION
Serve the webpack'ed version of the console
Expects 'prod:build' script to have been run before creating release archive version 