### PR TITLE
OHM-822 Update alpha release version

### DIFF
--- a/5-alpha/Dockerfile
+++ b/5-alpha/Dockerfile
@@ -3,7 +3,7 @@ FROM node:10.15.0
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
-ENV OPENHIM_CORE_VERSION 5.3.0-alpha.1
+ENV OPENHIM_CORE_VERSION 5.3.0-alpha.2
 
 RUN curl -sL "https://github.com/jembi/openhim-core-js/archive/v$OPENHIM_CORE_VERSION.tar.gz" | \
     tar --strip-components=1 -zxvf - && \


### PR DESCRIPTION
To build the latest OpenHIM 5.3 version

OHM-822