### PR TITLE
Update Console version to latest release

### DIFF
--- a/1.13/Dockerfile
+++ b/1.13/Dockerfile
@@ -2,6 +2,6 @@ FROM nginx:alpine
 
 WORKDIR /usr/share/nginx/html
 
-ENV OPENHIM_CONSOLE_VERSION 1.13.2
+ENV OPENHIM_CONSOLE_VERSION 1.13.3
 
 RUN wget -qO- "https://github.com/jembi/openhim-console/releases/download/v$OPENHIM_CONSOLE_VERSION/openhim-console-v$OPENHIM_CONSOLE_VERSION.tar.gz" | tar xvz


### PR DESCRIPTION
Allow dockerhub to build latest console version